### PR TITLE
Prevent accidental data loss

### DIFF
--- a/edit-file.js
+++ b/edit-file.js
@@ -14,7 +14,7 @@ const editFile = (file, edit, cb) => {
   fs.readFile(abs, utf8, (err, text) => {
     if (err) throw err
     text = edit(text)
-    if (void 0 === text) throw new Error("edit returned undefined")
+    if (void 0 === text) throw new Error("undefined edit return")
     fs.writeFile(abs, text, utf8, cb)
   })
 }

--- a/edit-file.js
+++ b/edit-file.js
@@ -14,6 +14,7 @@ const editFile = (file, edit, cb) => {
   fs.readFile(abs, utf8, (err, text) => {
     if (err) throw err
     text = edit(text)
+    if (void 0 === text) throw new Error("edit returned undefined")
     fs.writeFile(abs, text, utf8, cb)
   })
 }


### PR DESCRIPTION
Throw an error if `edit` returns `undefined` to prevent accidental data loss.